### PR TITLE
Improve sum check in general and preprocess for sum check in mlkzg `multi_open`

### DIFF
--- a/subroutines/src/pcs/multilinear_kzg/batching.rs
+++ b/subroutines/src/pcs/multilinear_kzg/batching.rs
@@ -23,8 +23,7 @@ use arithmetic::{build_eq_x_r_vec, DenseMultilinearExtension, VPAuxInfo, Virtual
 use ark_ec::{msm::VariableBaseMSM, PairingEngine, ProjectiveCurve};
 use ark_ff::PrimeField;
 use ark_std::{end_timer, log2, start_timer, One, Zero};
-use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
-use std::{marker::PhantomData, sync::Arc};
+use std::{collections::BTreeMap, marker::PhantomData, ops::Deref, sync::Arc};
 use transcript::IOPTranscript;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -80,22 +79,42 @@ where
 
     // \tilde g_i(b) = eq(t, i) * f_i(b)
     let timer = start_timer!(|| format!("compute tilde g for {} points", points.len()));
-    let mut tilde_gs = vec![];
-    for (index, f_i) in polynomials.iter().enumerate() {
-        let mut tilde_g_eval = vec![E::Fr::zero(); 1 << num_var];
-        for (j, &f_i_eval) in f_i.iter().enumerate() {
-            tilde_g_eval[j] = f_i_eval * eq_t_i_list[index];
-        }
-        tilde_gs.push(Arc::new(DenseMultilinearExtension::from_evaluations_vec(
-            num_var,
-            tilde_g_eval,
-        )));
-    }
+    let point_indices = points
+        .iter()
+        .fold(BTreeMap::<_, _>::new(), |mut indices, point| {
+            let idx = indices.len();
+            indices.entry(point).or_insert(idx);
+            indices
+        });
+    let deduped_points =
+        BTreeMap::from_iter(point_indices.iter().map(|(point, idx)| (*idx, *point)))
+            .into_values()
+            .collect::<Vec<_>>();
+    let merged_tilde_gs = polynomials
+        .iter()
+        .zip(points.iter())
+        .zip(eq_t_i_list.iter())
+        .fold(
+            (0..point_indices.len())
+                .map(|_| {
+                    DenseMultilinearExtension::from_evaluations_vec(
+                        num_var,
+                        vec![E::Fr::zero(); 1 << num_var],
+                    )
+                })
+                .map(Arc::new)
+                .collect::<Vec<_>>(),
+            |mut merged_tilde_gs, ((poly, point), coeff)| {
+                *Arc::make_mut(&mut merged_tilde_gs[point_indices[point]]) +=
+                    (*coeff, poly.deref());
+                merged_tilde_gs
+            },
+        );
     end_timer!(timer);
 
     let timer = start_timer!(|| format!("compute tilde eq for {} points", points.len()));
-    let tilde_eqs: Vec<Arc<DenseMultilinearExtension<<E as PairingEngine>::Fr>>> = points
-        .par_iter()
+    let tilde_eqs: Vec<_> = deduped_points
+        .iter()
         .map(|point| {
             let eq_b_zi = build_eq_x_r_vec(point).unwrap();
             Arc::new(DenseMultilinearExtension::from_evaluations_vec(
@@ -110,8 +129,8 @@ where
 
     let step = start_timer!(|| "add mle");
     let mut sum_check_vp = VirtualPolynomial::new(num_var);
-    for (tilde_g, tilde_eq) in tilde_gs.iter().zip(tilde_eqs.into_iter()) {
-        sum_check_vp.add_mle_list([tilde_g.clone(), tilde_eq], E::Fr::one())?;
+    for (merged_tilde_g, tilde_eq) in merged_tilde_gs.iter().zip(tilde_eqs.into_iter()) {
+        sum_check_vp.add_mle_list([merged_tilde_g.clone(), tilde_eq], E::Fr::one())?;
     }
     end_timer!(step);
 
@@ -133,17 +152,14 @@ where
     // build g'(X) = \sum_i=1..k \tilde eq_i(a2) * \tilde g_i(X) where (a2) is the
     // sumcheck's point \tilde eq_i(a2) = eq(a2, point_i)
     let step = start_timer!(|| "evaluate at a2");
-    let mut g_prime_evals = vec![E::Fr::zero(); 1 << num_var];
-    for (tilde_g, point) in tilde_gs.iter().zip(points.iter()) {
-        let eq_i_a2 = eq_eval(a2, point)?;
-        for (j, &tilde_g_eval) in tilde_g.iter().enumerate() {
-            g_prime_evals[j] += tilde_g_eval * eq_i_a2;
-        }
-    }
-    let g_prime = Arc::new(DenseMultilinearExtension::from_evaluations_vec(
+    let mut g_prime = Arc::new(DenseMultilinearExtension::from_evaluations_vec(
         num_var,
-        g_prime_evals,
+        vec![E::Fr::zero(); 1 << num_var],
     ));
+    for (merged_tilde_g, point) in merged_tilde_gs.iter().zip(deduped_points.iter()) {
+        let eq_i_a2 = eq_eval(a2, point)?;
+        *Arc::make_mut(&mut g_prime) += (eq_i_a2, merged_tilde_g.deref());
+    }
     end_timer!(step);
 
     let step = start_timer!(|| "pcs open");

--- a/subroutines/src/poly_iop/structs.rs
+++ b/subroutines/src/poly_iop/structs.rs
@@ -35,6 +35,9 @@ pub struct IOPProverState<F: PrimeField> {
     pub(crate) round: usize,
     /// pointer to the virtual polynomial
     pub(crate) poly: VirtualPolynomial<F>,
+    /// points with precomputed barycentric weights for extrapolating smaller
+    /// degree uni-polys to `max_degree + 1` evaluations.
+    pub(crate) extrapolation_aux: Vec<(Vec<F>, Vec<F>)>,
 }
 
 /// Prover State of a PolyIOP

--- a/subroutines/src/poly_iop/sum_check/prover.rs
+++ b/subroutines/src/poly_iop/sum_check/prover.rs
@@ -137,9 +137,10 @@ impl<F: PrimeField> SumCheckProver<F> for IOPProverState<F> {
                                 *eval = table[b << 1];
                                 *step = table[(b << 1) + 1] - table[b << 1];
                             });
-                        acc.iter_mut().for_each(|acc| {
-                            *acc += buf.iter().map(|(eval, _)| eval).product::<F>();
+                        acc[0] += buf.iter().map(|(eval, _)| eval).product::<F>();
+                        acc[1..].iter_mut().for_each(|acc| {
                             buf.iter_mut().for_each(|(eval, step)| *eval += step as &_);
+                            *acc += buf.iter().map(|(eval, _)| eval).product::<F>();
                         });
                         (buf, acc)
                     },


### PR DESCRIPTION
This PR does 2 changes:

- Improve sum check prover in general
  - Adopt the algorithm for sum check prover specified in https://github.com/EspressoSystems/hyperplonk/pull/89#discussion_r993493483.
  - Evaluate individual products at `products.len() +1` points instead of always `max_degree + 1` points, and extrapolate it to `max_degree + 1` points later.
- Preprocess more on mlkzg `multi_open` to combine the polys opening at the same point, to reduce the workload of updating the table.

## Comparison

Running `cargo bench --bench hyperplonk-benches --features print-trace` and extract the following trace components of `bench_vanilla_plonk` when `num_vars = 20`, the result is as follows:

| Name                  | Trace Components                                                                                       | Before                                  | After                                  | Ratio (Before/After) |
| --------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------- | -------------------------------------- | -------------------- |
| Gate ZeroCheck        | ZeroCheck on f                                                                                         | 345.313ms                               | 268.233ms                              | 1.287                |
| Permutation ZeroCheck | zerocheck in product check                                                                             | 424.487ms                               | 345.190ms                              | 1.229                |
| PCS SumCheck          | compute tilde g for 22 points <br> compute tilde eq for 22 points <br> sum check prove of 20 variables | 414.559ms <br> 100.478ms <br> 991.671ms | 110.617ms <br> 69.953ms <br> 235.245ms | 3.623                |
