### PR TITLE
small-fix: fix_one_variable_helper not-parallel behavior

### DIFF
--- a/arithmetic/src/multilinear_polynomial.rs
+++ b/arithmetic/src/multilinear_polynomial.rs
@@ -162,7 +162,7 @@ fn fix_one_variable_helper<F: Field>(data: &[F], nv: usize, point: &F) -> Vec<F>
     // evaluate single variable of partial point from left to right
     #[cfg(not(feature = "parallel"))]
     for i in 0..(1 << (nv - 1)) {
-        res[i] = data[i] + (data[(i << 1) + 1] - data[i << 1]) * point;
+        res[i] = data[i << 1] + (data[(i << 1) + 1] - data[i << 1]) * point;
     }
 
     #[cfg(feature = "parallel")]


### PR DESCRIPTION
I was using the parallel & non-parallel versions of `fix_one_variable_helper`, and found out that they differ.
This PR adapts the non-parallel version to behave as the parallel one, since is the same behavior than in [arkworks/algebra/poly/src/evaluations/multivariate/multilinear/dense.rs](
https://github.com/arkworks-rs/algebra/blob/66ca8ed0f88955c573c077da9134f2db29e18c19/poly/src/evaluations/multivariate/multilinear/dense.rs#L151).