### PR TITLE
Fix Typos in `readme.md`: Add Hyphen to "User-Friendly

### DIFF
--- a/subroutines/src/pcs/readme.md
+++ b/subroutines/src/pcs/readme.md
@@ -3,5 +3,5 @@ KZG based multilinear polynomial commitment
 
 # Compiling features:
 - `parallel`: use multi-threading when possible.
-- `print-trace`: print out user friendly information about the running time for each micro component.
+- `print-trace`: print out user-friendly information about the running time for each micro component.
 - `extensive_sanity_checks`: runs additional sanity checks that is not essential and will slow down the scheme.


### PR DESCRIPTION
This PR addresses a minor typo in the `readme.md` file for the `subroutines/src/pcs` directory. 

Specifically:  
- Corrected **"user friendly"** to **"user-friendly"** to follow proper hyphenation rules for compound adjectives.  

### Why this change is necessary  
Maintaining correct spelling and grammar ensures clarity and professionalism in documentation, improving the overall user experience.

### Key places to review  
- `subroutines/src/pcs/readme.md`: Line updated where "user friendly" was changed to "user-friendly."
