### PR TITLE
Typo errors.rs

### DIFF
--- a/arithmetic/src/errors.rs
+++ b/arithmetic/src/errors.rs
@@ -9,7 +9,7 @@
 use ark_std::string::String;
 use displaydoc::Display;
 
-/// A `enum` specifying the possible failure modes of the arithmetics.
+/// A `enum` specifying the possible failure modes of the arithmetic.
 #[derive(Display, Debug)]
 pub enum ArithErrors {
     /// Invalid parameters: {0}


### PR DESCRIPTION
# Typo errors.rs

## Description
This pull request fixes a typo in the `arithmetic/src/errors.rs` file, where the word "arithmetics" was corrected to "arithmetic" in the enum documentation.

## Changes Made
- Corrected the typo in the documentation from "arithmetics" to "arithmetic."

## Files Changed
- `arithmetic/src/errors.rs`


