### PR TITLE
fix: append eval and eval_point to transcript

### DIFF
--- a/hyperplonk/src/snark.rs
+++ b/hyperplonk/src/snark.rs
@@ -337,6 +337,12 @@ where
         // =======================================================================
         // 5. deferred batch opening
         // =======================================================================
+        for eval_point in pcs_acc.points.iter() {
+            transcript.append_serializable_element(b"eval_point", eval_point)?;
+        }
+        for eval in pcs_acc.evals.iter() {
+            transcript.append_field_element(b"eval", eval)?;
+        }
         let step = start_timer!(|| "deferred batch openings prod(x)");
         let batch_openings = pcs_acc.multi_open(&pk.pcs_param, &mut transcript)?;
         end_timer!(step);
@@ -605,6 +611,22 @@ where
         end_timer!(pi_step);
 
         end_timer!(step);
+
+        for eval_point in points.iter() {
+            transcript.append_serializable_element(b"eval_point", eval_point)?;
+        }
+        for eval in prod_evals
+            .iter()
+            .chain(frac_evals)
+            .chain(perm_evals)
+            .chain(witness_perm_evals)
+            .chain(witness_gate_evals)
+            .chain(selector_evals)
+            .chain([pi_eval])
+        {
+            transcript.append_field_element(b"eval", eval)?;
+        }
+
         let step = start_timer!(|| "PCS batch verify");
         // check proof
         let res = PCS::batch_verify(

--- a/hyperplonk/src/snark.rs
+++ b/hyperplonk/src/snark.rs
@@ -337,12 +337,6 @@ where
         // =======================================================================
         // 5. deferred batch opening
         // =======================================================================
-        for eval_point in pcs_acc.points.iter() {
-            transcript.append_serializable_element(b"eval_point", eval_point)?;
-        }
-        for eval in pcs_acc.evals.iter() {
-            transcript.append_field_element(b"eval", eval)?;
-        }
         let step = start_timer!(|| "deferred batch openings prod(x)");
         let batch_openings = pcs_acc.multi_open(&pk.pcs_param, &mut transcript)?;
         end_timer!(step);
@@ -609,23 +603,7 @@ where
         points.push(r_pi_padded);
         assert_eq!(comms.len(), proof.batch_openings.f_i_eval_at_point_i.len());
         end_timer!(pi_step);
-
         end_timer!(step);
-
-        for eval_point in points.iter() {
-            transcript.append_serializable_element(b"eval_point", eval_point)?;
-        }
-        for eval in prod_evals
-            .iter()
-            .chain(frac_evals)
-            .chain(perm_evals)
-            .chain(witness_perm_evals)
-            .chain(witness_gate_evals)
-            .chain(selector_evals)
-            .chain([pi_eval])
-        {
-            transcript.append_field_element(b"eval", eval)?;
-        }
 
         let step = start_timer!(|| "PCS batch verify");
         // check proof

--- a/subroutines/src/pcs/multilinear_kzg/batching.rs
+++ b/subroutines/src/pcs/multilinear_kzg/batching.rs
@@ -65,6 +65,12 @@ where
     >,
 {
     let open_timer = start_timer!(|| format!("multi open {} points", points.len()));
+    for eval_point in points.iter() {
+        transcript.append_serializable_element(b"eval_point", eval_point)?;
+    }
+    for eval in evals.iter() {
+        transcript.append_field_element(b"eval", eval)?;
+    }
 
     // TODO: sanity checks
     let num_var = polynomials[0].num_vars;
@@ -198,6 +204,12 @@ where
     >,
 {
     let open_timer = start_timer!(|| "batch verification");
+    for eval_point in points.iter() {
+        transcript.append_serializable_element(b"eval_point", eval_point)?;
+    }
+    for eval in proof.f_i_eval_at_point_i.iter() {
+        transcript.append_field_element(b"eval", eval)?;
+    }
 
     // TODO: sanity checks
 


### PR DESCRIPTION
Closes #173 

### This PR:

Append `eval` and `eval_points` to FS transcript before doing the batch opening (or the verification) to prevent malicious prover attack.
