### PR TITLE
Fix incorrect `log2` calculation in `HyperPlonkParams::num_variables`

### DIFF
--- a/hyperplonk/src/structs.rs
+++ b/hyperplonk/src/structs.rs
@@ -60,7 +60,7 @@ pub struct HyperPlonkParams {
 impl HyperPlonkParams {
     /// Number of variables in a multilinear system
     pub fn num_variables(&self) -> usize {
-        log2(self.num_constraints) as usize
+        log2(self.num_constraints.next_power_of_two()) as usize
     }
 
     /// number of selector columns


### PR DESCRIPTION
Fixed `log2` calculation by using `log2(self.num_constraints.next_power_of_two()) as usize`.  
  - Prevents incorrect rounding errors.  
  - Ensures proper handling of non-power-of-two values.  

### Why is this needed?  
If `num_constraints` is not a power of two, `log2(num_constraints)` returns a floating-point number, which can lead to incorrect truncation when cast to `usize`. Using `next_power_of_two()` ensures that `log2` always receives a valid power of two, preventing potential off-by-one errors.  