### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -20,7 +20,7 @@ jobs:
         uses: cachix/install-nix-action@V27
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # sanity check that repository builds with nix
       - name: Build


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0